### PR TITLE
Fixed laser not rendering on ship and raytrece rendering pass through block

### DIFF
--- a/src/main/java/omtteam/openmodularturrets/tileentity/turrets/LaserTurretTileEntity.java
+++ b/src/main/java/omtteam/openmodularturrets/tileentity/turrets/LaserTurretTileEntity.java
@@ -65,15 +65,7 @@ public class LaserTurretTileEntity extends RayTracingTurret {
     }
 
     @Override
-    protected void renderRay(Vec3d start, Vec3d end) {if (ModCompatibility.ValkyrienWarfareLoaded) {
-
-        IPhysicsEntity physicsEntity = IPhysicsEntityManager.INSTANCE.getPhysicsEntityFromShipSpace(getWorld(),
-                getPos());
-        if (physicsEntity != null) {
-            start = physicsEntity.transformVector(start, TransformType.SUBSPACE_TO_GLOBAL);
-            end = physicsEntity.transformVector(end, TransformType.SUBSPACE_TO_GLOBAL);
-        }
-    }
+    protected void renderRay(Vec3d start, Vec3d end) {
         OMLibNetworkingHandler.INSTANCE.sendToAllAround(
                 new MessageRenderRay(start, end, color, 5, true),
                 new NetworkRegistry.TargetPoint(this.getWorld().provider.getDimension(),

--- a/src/main/java/omtteam/openmodularturrets/tileentity/turrets/RayTracingTurret.java
+++ b/src/main/java/omtteam/openmodularturrets/tileentity/turrets/RayTracingTurret.java
@@ -138,9 +138,13 @@ public abstract class RayTracingTurret extends AbstractDirectedTurret {
             }
             if (!hit) {
                 if (blockTraceResult != null && blockTraceResult.typeOfHit == RayTraceResult.Type.BLOCK) {
-                    handleBlockHit(world.getBlockState(blockTraceResult.getBlockPos()), blockTraceResult.getBlockPos());
+                    if (baseVector.distanceTo(blockTraceResult.hitVec) <= blockRange) {
+                        this.renderRay(baseVector, blockTraceResult.hitVec);
+                        handleBlockHit(world.getBlockState(blockTraceResult.getBlockPos()), blockTraceResult.getBlockPos());
+                    }
+                }else {
+                    this.renderRay(baseVector, vector.add(vector.subtract(baseVector).scale(2D)));
                 }
-                this.renderRay(baseVector, vector.add(vector.subtract(baseVector).scale(2D)));
             }
         }
     }


### PR DESCRIPTION
Hi Keridos, I just find an issue with laser not rendering on VS ship and got it fixed. I also fixed raytracing rendering through blocks when blocks get hits by raytracing turrets. Also by the way can you make an curseforge update for 3.1.x Valkyrien Skies compatible version? 